### PR TITLE
initial

### DIFF
--- a/Command/RefreshTokensCommand.php
+++ b/Command/RefreshTokensCommand.php
@@ -63,15 +63,22 @@ class RefreshTokensCommand extends ContainerAwareCommand
             $shops = $repo->findByApplication($id);
 
             foreach ($shops as $s) {
-                $client = $obj->getClient($s);
-                $refresher->setClient($client);
+                if ($s->getInstalled()) {
+                    if ($s->getToken()->getExpiresAt()->getTimestamp() <= time() + 604800
+                    && $s->getToken()->getExpiresAt()->getTimestamp() >= time()
+                    ) {
+                        $client = $obj->getClient($s);
+                        $refresher->setClient($client);
 
-                try {
-                    $output->writeln(sprintf('Refreshing shop: %s # %s', $s->getShopUrl(), $s->getName()));
-                    $refresher->refresh($s);
-                    $output->writeln('Done');
-                } catch (\Exception $ex) {
-                    $output->writeln('<error>An error occurred during the token refresh</error>');
+                        try {
+                            $output->writeln(sprintf('Refreshing shop: %s # %s', $s->getShopUrl(), $s->getName()));
+                            $refresher->refresh($s);
+                            $output->writeln('Done');
+                        } catch (\Exception $ex) {
+                            $output->writeln('<error>An error occurred during the token refresh</error>');
+                        }
+                    }
+
                 }
             }
         }

--- a/EventListener/ApplicationControllerListener.php
+++ b/EventListener/ApplicationControllerListener.php
@@ -131,7 +131,7 @@ class ApplicationControllerListener{
             $shop = $repo->findOneByNameAndApplication($params['shop'], $appName);
 
             // not installed - throw an error
-            if(!$shop){
+            if (!$shop || !$shop->getInstalled()){
                 $this->redirect($event, 'not_installed');
             }
 

--- a/EventListener/AppstoreListener.php
+++ b/EventListener/AppstoreListener.php
@@ -73,10 +73,14 @@ class AppstoreListener{
 
         // extract shop entity from event
         $shop = $this->getShopByEvent($event);
-
+        $update = false;
         // already installed, skip
         if($shop){
-            return false;
+            if ($shop->getInstalled()) {
+                return false;
+            } else {
+                $update = true;
+            }
         }
 
         $shopChecker = new ShopChecker();
@@ -88,7 +92,8 @@ class AppstoreListener{
 
             $url = $shopChecker->getRealShopUrl($params['shop_url']);
             if(!$url){
-                throw new Exception('Cannot determine real URL for: '.$params['shop_url']);
+                $url = $params['shop_url'];
+                //throw new Exception($url.' - Cannot determine real URL for: '.$params['shop_url']);
             }
 
             // perform client instantiation
@@ -113,22 +118,30 @@ class AppstoreListener{
         }
 
         // region shop
-        /**
-         * @var $shopModel ShopInterface
-         */
-        $shopModel = $this->objectManager->create('DreamCommerce\ShopAppstoreBundle\Model\ShopInterface');
+        if ($update) {
+            $shopModel = $shop;
+        } else {
+            /**
+             * @var $shopModel ShopInterface
+             */
+            $shopModel = $this->objectManager->create('DreamCommerce\ShopAppstoreBundle\Model\ShopInterface');
+        }
         $shopModel->setApp($event->getApplicationName());
         $shopModel->setName($params['shop']);
         $shopModel->setShopUrl($url);
         $shopModel->setVersion($params['application_version']);
+        $shopModel->setInstalled(true);
         $this->objectManager->save($shopModel, false);
         // endregion
 
         // region token
-        /**
-         * @var $tokenModel TokenInterface
-         */
-        $tokenModel = $this->objectManager->create('DreamCommerce\ShopAppstoreBundle\Model\TokenInterface');
+        if ($update) {
+            $tokenModel = $shop->getToken();
+        } else {
+            /** @var $tokenModel TokenInterface */
+            $tokenModel = $this->objectManager->create('DreamCommerce\ShopAppstoreBundle\Model\TokenInterface');
+        }
+
         $tokenModel->setAccessToken($token['access_token']);
         $tokenModel->setRefreshToken($token['refresh_token']);
 
@@ -152,12 +165,12 @@ class AppstoreListener{
 
         $shop = $this->getShopByEvent($event);
 
-        if(!$shop){
+        if(!$shop || !$shop->getInstalled()){
             return false;
         }
 
-        // simply delete entity by manager
-        $this->objectManager->delete($shop);
+        $shop->setInstalled(false);
+        $this->objectManager->save($shop);
     }
 
     /**
@@ -169,7 +182,7 @@ class AppstoreListener{
 
         $shop = $this->getShopByEvent($event);
 
-        if(!$shop){
+        if(!$shop || !$shop->getInstalled()){
             return false;
         }
 
@@ -191,7 +204,7 @@ class AppstoreListener{
 
         $shop = $this->getShopByEvent($event);
 
-        if(!$shop){
+        if(!$shop || !$shop->getInstalled()){
             return false;
         }
 
@@ -218,7 +231,7 @@ class AppstoreListener{
     public function onUpgrade(UpgradeEvent $event){
         $shop = $this->getShopByEvent($event);
 
-        if(!$shop){
+        if(!$shop || !$shop->getInstalled()){
             return false;
         }
 

--- a/Model/Shop.php
+++ b/Model/Shop.php
@@ -51,6 +51,12 @@ abstract class Shop implements ShopInterface
     protected $version;
 
     /**
+     * is installed
+     * @var bool
+     */
+    protected $installed;
+
+    /**
      * @inheritdoc
      */
     public function setName($name)
@@ -154,5 +160,24 @@ abstract class Shop implements ShopInterface
     public function setVersion($version)
     {
         $this->version = $version;
+    }
+
+    /**
+     * get installed
+     * @return bool
+     */
+    public function getInstalled()
+    {
+        return $this->installed;
+    }
+
+    /**
+     * set installed
+     * @param bool $installed
+     * @return void
+     */
+    public function setInstalled($installed)
+    {
+        $this->installed = $installed;
     }
 }

--- a/Model/ShopInterface.php
+++ b/Model/ShopInterface.php
@@ -92,4 +92,17 @@ interface ShopInterface
      * @return void
      */
     public function setVersion($version);
+
+    /**
+     * get installed
+     * @return bool
+     */
+    public function getInstalled();
+
+    /**
+     * set installed
+     * @param bool $installed
+     * @return void
+     */
+    public function setInstalled($installed);
 }

--- a/Resources/config/doctrine/model/Shop.orm.xml
+++ b/Resources/config/doctrine/model/Shop.orm.xml
@@ -10,5 +10,6 @@
         <field name="shopUrl" type="string" column="shop_url" length="512" nullable="false"/>
         <field name="app" type="string" column="app" length="40" nullable="false"/>
         <field name="version" type="integer" column="version"/>
+        <field name="installed" type="boolean" column="installed"/>
     </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
- dodanie flagi czy sklep jest zainstalowany,
- optymalizacja crona,
+ myślę, że tak będzie lepiej:
- zmiana zasady działania w wypadku, kiedy nie uda się ustaliś adresu sklepu korzystając z metody
$shopChecker->getRealShopUrl($params['shop_url'])
zmiast rzucać wyjątkiem, zastosowanie użycie przesłanego przez appstore adresu sklepu.